### PR TITLE
added a colored console output target

### DIFF
--- a/target/color_writer.go
+++ b/target/color_writer.go
@@ -1,0 +1,47 @@
+package target
+
+import (
+	"io"
+
+	"github.com/fatih/color"
+	"github.com/jerejones/jlog/event"
+	"github.com/jerejones/jlog/renderer"
+	"github.com/pkg/errors"
+)
+
+type ColorWriterTarget struct {
+	io.Writer
+	Layout   string
+	Renderer renderer.Renderer
+	colors   map[event.Level]*color.Color
+}
+
+func NewColorWriter(w io.Writer, spec Config) (Target, error) {
+	rndr, err := renderer.New(spec.Layout)
+	if err != nil {
+		return nil, errors.Wrap(err, "bad layout")
+	}
+
+	colors := map[event.Level]*color.Color{
+		event.ErrorLevel:   color.New(color.FgRed),
+		event.DebugLevel:   color.New(color.FgHiBlue),
+		event.WarnLevel:    color.New(color.FgYellow),
+		event.InfoLevel:    color.New(color.FgWhite),
+		event.UnknownLevel: color.New(color.FgWhite),
+	}
+
+	return &ColorWriterTarget{
+		Writer:   w,
+		Layout:   spec.Layout,
+		Renderer: rndr,
+		colors:   colors,
+	}, nil
+}
+
+func (t *ColorWriterTarget) Write(info event.Info) {
+	if c, ok := t.colors[info.Level]; ok {
+		c.Fprintf(t.Writer, t.Renderer.Render(info)+"\n")
+		return
+	}
+	t.colors[event.UnknownLevel].Fprintf(t.Writer, t.Renderer.Render(info)+"\n")
+}

--- a/target/color_writer_test.go
+++ b/target/color_writer_test.go
@@ -1,0 +1,30 @@
+package target
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/jerejones/jlog/event"
+)
+
+func TestColorWriter(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{})
+	w, err := NewColorWriter(buf, Config{
+		Layout: "${level} ${message}\n",
+	})
+	if err != nil {
+		t.Errorf("Error return from NewWriter: %s", err)
+	}
+
+	str := buf.String()
+
+	info := event.Info{
+		Message: "Test Message",
+		Level:   event.ErrorLevel,
+	}
+
+	w.Write(info)
+
+	str = buf.String()
+	assertContains(t, str, "Test Message")
+}

--- a/target/colored_console.go
+++ b/target/colored_console.go
@@ -1,0 +1,40 @@
+package target
+
+import (
+	"os"
+
+	"github.com/jerejones/jlog/event"
+)
+
+func init() {
+	RegisterTargetFactory("coloredconsole", NewColoredConsole)
+}
+
+type ColoredConsoleTarget struct {
+	stderr Target
+	stdout Target
+}
+
+func NewColoredConsole(spec Config) (Target, error) {
+	stderr, err := NewColorWriter(os.Stderr, spec)
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := NewColorWriter(os.Stdout, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ColoredConsoleTarget{
+		stderr: stderr,
+		stdout: stdout,
+	}, nil
+}
+
+func (t *ColoredConsoleTarget) Write(info event.Info) {
+	if info.Level < event.ErrorLevel {
+		t.stdout.Write(info)
+	} else {
+		t.stderr.Write(info)
+	}
+}

--- a/target/colored_console_test.go
+++ b/target/colored_console_test.go
@@ -1,0 +1,51 @@
+package target
+
+import (
+	"testing"
+
+	"github.com/jerejones/jlog/event"
+)
+
+func TestColoredConsole(t *testing.T) {
+	tt := []struct {
+		name           string
+		level          event.Level
+		expectedStdOut string
+		expectedStdErr string
+	}{
+		{name: "debug to stdout", level: event.DebugLevel, expectedStdOut: "DEBUG"},
+		{name: "info to stdout", level: event.InfoLevel, expectedStdOut: "INFO "},
+		{name: "warn to stdout", level: event.WarnLevel, expectedStdOut: "WARN "},
+		{name: "error to stderr", level: event.ErrorLevel, expectedStdErr: "ERROR"},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			origStdOut, origStdErr, ow, oC, ew, eC := startStdOutErrCapture()
+			tgt, _ := NewColoredConsole(Config{
+				Name:   "stdout",
+				Layout: "[${level}] ${message}",
+			})
+
+			tgt.Write(event.Info{
+				Level:   tc.level,
+				Message: "I'm alive!!",
+			})
+
+			stdout, stderr := captureStdOutErr(ow, oC, ew, eC)
+
+			if len(tc.expectedStdErr) > 0 {
+				assertNotContains(t, stdout, "I'm alive!!")
+				assertNotContains(t, stdout, tc.expectedStdErr)
+				assertContains(t, stderr, "I'm alive!!")
+				assertContains(t, stderr, tc.expectedStdErr)
+			} else {
+				assertContains(t, stdout, "I'm alive!!")
+				assertContains(t, stdout, tc.expectedStdOut)
+				assertNotContains(t, stderr, "I'm alive!!")
+				assertNotContains(t, stderr, tc.expectedStdOut)
+			}
+			restoreStdOutErr(origStdOut, origStdErr)
+		})
+	}
+}


### PR DESCRIPTION
I was thinking it may make more sense to add a new config such as "UseColoredOutput" or something vs having a whole new console target which doesn't do much but uses the color_writer. Let me know.